### PR TITLE
Fix cache merging

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,12 @@ function StatsPlugin (output, options, cache) {
   this.cache = cache
 }
 
+function mergeCustomizer (objValue, srcValue) {
+  if (_.isArray(objValue)) {
+    return _.unionWith(objValue, srcValue, _.isEqual)
+  }
+}
+
 StatsPlugin.prototype.apply = function apply (compiler) {
   var output = this.output
   var options = this.options
@@ -31,7 +37,7 @@ StatsPlugin.prototype.apply = function apply (compiler) {
         var result
 
         if (cache) {
-          cache = _.merge(cache, stats)
+          cache = _.mergeWith(cache, stats, mergeCustomizer)
           if (stats.errors) cache.errors = stats.errors
           if (stats.warnings) cache.warnings = stats.warnings
           result = JSON.stringify(cache)

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -98,7 +98,12 @@ describe('StatsWebpackPlugin', function () {
         file1: 'bundle1.js',
         file2: 'bundle2.js'
       }
+      var actualAssetNames = actual.assets.map(function (asset) {
+        return asset.name
+      })
+
       expect(actual.assetsByChunkName).to.deep.equal(expectedAssetsByChunkName)
+      expect(actualAssetNames).to.include.members(['bundle1.js', 'bundle2.js'])
       done()
     })
   })


### PR DESCRIPTION
When using multicompiler with cache, all of the arrays in cache should be united
not replaced.

Taking example from the unit tests, the final `stats.assets` should contain both
`bundle1.js` and `bundle2.js`